### PR TITLE
ISO8601DurationFormatter

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1205,6 +1205,7 @@
   "https://github.com/kjoneandrei/BRPageControl.git",
   "https://github.com/kkbox/openapi-swift-promises.git",
   "https://github.com/KKBOX/OpenAPI-Swift.git",
+  "https://github.com/kkla320/ISO8601DurationFormatter.git",
   "https://github.com/klundberg/CopyOnWrite.git",
   "https://github.com/klundberg/Weakify.git",
   "https://github.com/koderinc/KDKeyboardTracker.git",


### PR DESCRIPTION
## Checklist

* [x] My repositories are publicly accessible
* [x] My packages contain a Package.swift file in the root folder
* [x] My packages are written in Swift 4.0 or later
* [x] My package creates at least one product (library or executable)
* [x] My package has at least one release using a git tag conforming to the [semantic version](https://semver.org/) spec. (It can be beta or pre-release)
* [x] My package compiles without errors
* [x] My package outputs valid JSON from `swift package dump-package` with the latest Swift toolchain
* [x] My package URLs are fully specified including `https` and the `.git` extension
* [x] I have run `swift ./validate.swift diff` before submitting

## ISO8601DurationFormatter

A formatter for converting [ISO 8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) to DateComponents.